### PR TITLE
Grouping mypy packages at Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,16 @@
 {
   "extends": [
     "config:base"
-  ]
+  ],
+  "pip_requirements": {
+    "packageRules": [
+      {
+        "groupName": "mypy packages",
+        "packageNames": [
+          "mypy",
+          "typed-ast"
+        ]
+      }
+    ]
+  }
 }


### PR DESCRIPTION
typed-ast is depended by mypy.
So it should be updated in same time.